### PR TITLE
Updated both root and example README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 <!-- markdownlint-disable MD041 -->
-<p align="center"><a href="https://github.com/fredrikhgrelland/vagrant-hashistack-template" alt="Built on"><img src="https://img.shields.io/badge/Built%20from%20template-Vagrant--hashistack--template-blue?style=for-the-badge&logo=github"/></a><p align="center"><a href="https://github.com/fredrikhgrelland/vagrant-hashistack" alt="Built on"><img src="https://img.shields.io/badge/Powered%20by%20-Vagrant--hashistack-orange?style=for-the-badge&logo=vagrant"/></a></p></p>
+<p align="center"><img width="100px" src="https://www.svgrepo.com/show/48203/chart.svg" align="center" alt="Vagrant-hashistack" /><h2 align="center">Redash Terraform Module</h2></p><p align="center"><a href="https://github.com/fredrikhgrelland/vagrant-hashistack-template" alt="Built on"><img src="https://img.shields.io/badge/Built%20from%20template-Vagrant--hashistack--template-blue?style=for-the-badge&logo=github"/></a><p align="center"><a href="https://github.com/fredrikhgrelland/vagrant-hashistack" alt="Built on"><img src="https://img.shields.io/badge/Powered%20by%20-Vagrant--hashistack-orange?style=for-the-badge&logo=vagrant"/></a></p></p>
 
-# Redash terraform module
+## Contents
+1. [Compatibility](#compatibility)
+2. [Usage](#usage)
+   1. [Requirements](#requirements)
+      1. [Required software](#required-software)
+   2. [Providers](#providers)
+3. [Inputs](#inputs)
+4. [Outputs](#outputs)
+5. [Examples](#examples)
+6. [Authors](#authors)
+7. [License](#license)
 
 ## Compatibility
 |Software|OSS Version|Enterprise Version|
@@ -12,29 +22,13 @@
 |Nomad|0.12.3 or newer|0.12.3 or newer|
 
 ## Usage
-
-### Starting datastack
-Run
-```makefile
-make up
-```
-in your terminal to provision the datastack. When the process is finished you can then open up access to Redash, Presto, and MinIO by running
-```makefile
-make connect-to-all
-```
-which will open 3 terminal windows each with a connection to one of the components. Alternatively you can run `make proxy-redash`, `make proxy-presto`, and `make proxy-minio` to open individual proxy connections.
-
 ### Requirements
-#### Required modules
-- [MinIO](https://github.com/fredrikhgrelland/terraform-nomad-minio)
-- [Hive](https://github.com/fredrikhgrelland/terraform-nomad-hive)
 
 #### Required software
-- [GNU make](https://man7.org/linux/man-pages/man1/make.1.html)
-- [consul](https://www.consul.io/)
+See [template README's prerequisites](template_README.md#install-prerequisites).
 
 ### Providers
-This module uses the [Nomad](https://registry.terraform.io/providers/hashicorp/nomad/latest/docs).
+This module uses the [Nomad](https://registry.terraform.io/providers/hashicorp/nomad/latest/docs) provider.
 
 ## Inputs
 |Name     |Description     |Type    |Default |Required  |
@@ -46,13 +40,20 @@ This module uses the [Nomad](https://registry.terraform.io/providers/hashicorp/n
 |:--|:--|:--|:-:|:-:|
 |         |                |bool    |true    |yes         |
 
-### Example
-Example-code that shows how to use the module, and, if applicable, its different use cases.
+## Examples
+ Import module:
 ```hcl-terraform
 module "example"{
   source = "github.com/fredrikhgrelland/terraform-nomad-redash.git?ref=0.0.1"
 }
 ```
+
+There are also several examples using this terraform module:
+
+|Name|Path to Documentation|Description|
+|:--|:--|:--|
+|Datastack|[example/datastack](example/datastack/README.md)|Sets up a full datastack with Redash, Presto, and MinIO|
+|Redash one node|[example/redash_one_node/](example/redash_one_node/README.md)|Sets up a single instance of Redash and its UI|
 
 ### Verifying setup
 Description of expected end result and how to check it. E.g. "After a successful run Presto should be available at localhost:8080".

--- a/example/datastack/README.md
+++ b/example/datastack/README.md
@@ -1,0 +1,58 @@
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD028 -->
+<p align="center"><img width="100px" src="https://www.svgrepo.com/show/12675/bar-chart.svg" align="center" alt="Vagrant-hashistack" /><h2 align="center">Datastack with Redash</h2></p>
+
+## Content
+1. [Introduction](#introduction)
+2. [Requirements](#requirements)
+3. [Starting Datastack](#starting-datastack)
+4. [A note about MinIO](#a-note-about-minio)
+5. [Access Redash, MinIO and Presto](#access-redash-minio-and-presto)
+6. [Consul Connect and Proxies](#consul-connect-and-proxies)
+
+## Introduction
+This example provisions a full datastack.
+
+Provisioned stack:
+- [MinIO](https://min.io/) (storage)
+- [Presto](https://prestodb.io/) (SQL-engine)
+- [Redash](https://redash.io/) (Interface for writing SQL to Presto)
+
+## Requirements
+See [prerequisites](../../template_README.md#install-prerequisites)
+
+### Starting Datastack
+Run
+```makefile
+make up
+```
+in your terminal to provision the datastack.
+
+### A note about MinIO
+This example will set up _two_ MinIOs. There is one bundled with the vagrant-box that is used by the developers of this repository for _development_. In addition to this, this example sets up another MinIO that is intended to be used together with Redash and Presto. Read [Access Redash, MinIO and Presto](#access-redash-minio-and-presto) on how to connect to the latter.
+
+
+### Access Redash, MinIO and Presto
+When provisioning of the example is finished you can then open up access to Redash, Presto, and MinIO by running
+```makefile
+make connect-to-all
+```
+
+> :warning: [gnome-terminal](https://help.gnome.org/users/gnome-terminal/stable/) is required for the command above. If you do not have gnome-terminal you can run `make proxy-redash`, `make proxy-presto`, and `make proxy-presto` in three separate terminal windows to achieve the same as `make connect-to-all`.
+
+You will now have access to Redash, Presto, and MinIO on the addresses below:
+
+|Service|Address|
+|:--|:--|
+|Redash|[localhost:7070](localhost:7070)|
+|Presto|[localhost:8080](localhost:8080)|
+|MinIO|[localhost:9090](localhost:9090)|
+
+Read [Consul Connect and Proxies](#consul-connect-and-proxies) if you want to know more about why you have to run `make connect-to-all`.
+
+### Consul Connect and Proxies
+All services set up via this example utilise a feature called [Consul Connect](https://www.consul.io/docs/connect). The services are segregated and are placed in their own bubbles. The only way to channelise the flow of information in and out of these bubbles is by using consul-connect integrated proxies. When all the information travels in and out through one feature that we control (our consul-connect enabled proxies), it is a lot easier to secure the communication between services.
+
+> :bulb: We use the [Envoy proxy](https://www.envoyproxy.io/), which is natively supported by consul-connect.
+
+In order to access any of these "service-bubbles" from our machine we need to start proxies that can send information from our computer to the proxies within the "service-bubbles". This is what `make proxy-redash`, `make proxy-presto`, and `make proxy-minio` all do. Each one opens a proxy from our machine to the respective service. `make connect-to-all` opens all three with one command.

--- a/example/redash_one_node/README.md
+++ b/example/redash_one_node/README.md
@@ -1,0 +1,3 @@
+# Redash One Node
+
+This example sets up a single instance of Redash.


### PR DESCRIPTION
closes #15 
closes #16 
[Link to branch](https://github.com/fredrikhgrelland/terraform-nomad-redash/tree/doc-updates)

You should check out both the root README and the "Datatstack" README when reviewing this PR.

Added sections:
- Content headers
- A Note About MinIO
- Access Redash, Presto, and MinIO
- Consul Connect and Proxies

Added SVGs to top of READMEs for some flair.