### PR TITLE
Added default admin user for redash on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - update-box as a prereq for the template-example target in the makefile
 - Check for presence of consul binary
 - Consul in the Required software section of the README file
+- default admin user for redash on startup
 
 ### Fixed
 - Corrected the link to the proxy section that shows up when the make command fails

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Compatibility
 |Software|OSS Version|Enterprise Version|
-|:--|:--|:--|
+|:---|:---|:---|
 |Terraform|0.13.1 or newer||
 |Consul|1.8.3 or newer|1.8.3 or newer|
 |Vault|1.5.2.1 or newer|1.5.2.1 or newer|
@@ -31,14 +31,19 @@ See [template README's prerequisites](template_README.md#install-prerequisites).
 This module uses the [Nomad](https://registry.terraform.io/providers/hashicorp/nomad/latest/docs) provider.
 
 ## Inputs
-|Name     |Description     |Type    |Default |Required  |
-|:--|:--|:--|:-:|:-:|
-|         |                |bool    |true    |yes        |
+Name     |Description     |Type    |Default |Required   |
+|:---|:---|:---|:---|:---|
+|   redash_email_id   | Redash admin username| string    |admin@mail.com    |   no |
+|   redash_password  |  Redash admin password| string    |admin123         |    no |
+|   redash_username |   Redash admin username| string    |admin           |     no |
+
 
 ## Outputs
 |Name     |Description     |Type    |Default |Required   |
-|:--|:--|:--|:-:|:-:|
-|         |                |bool    |true    |yes         |
+|:---|:---|:---|:---|:---|
+|   redash_email_id   | Redash admin username| string    |admin@mail.com    |   no |
+|   redash_password  |  Redash admin password| string    |admin123         |    no |
+|   redash_username |   Redash admin username| string    |admin           |     no |
 
 ## Examples
  Import module:

--- a/conf/nomad/redash_server.hcl
+++ b/conf/nomad/redash_server.hcl
@@ -52,7 +52,7 @@ job "redash-server" {
         command = "/bin/bash"
         args = [
           "-c",
-          "python /app/manage.py database create_tables && /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w4 redash.wsgi:app --max-requests 1000 --max-requests-jitter 100"
+          "python /app/manage.py database create_tables && python /app/manage.py users create_root ${redash_admin_email_id} ${redash_admin_username} --password ${redash_admin_password} --org default && /usr/local/bin/gunicorn -b 0.0.0.0:5000 --name redash -w4 redash.wsgi:app --max-requests 1000 --max-requests-jitter 100"
         ]
       }
 

--- a/example/datastack/main.tf
+++ b/example/datastack/main.tf
@@ -115,7 +115,27 @@ module "presto" {
 
 module "redash" {
   source = "../../"
+
+  redash_admin_username ="admin"
+  redash_admin_password = "admin123"
+  redash_admin_email_id  = "admin@mail.com"
+
   depends_on = [
     module.presto
   ]
+}
+
+output "redash_username"{
+  description = "Redash admin username"
+  value= module.redash.redash_admin_username
+}
+
+output "redash_password" {
+  description = "Redash admin password"
+  value       = module.redash.redash_admin_password
+}
+
+output "redash_email_id" {
+  description = "Redash admin email id"
+  value       = module.redash.redash_admin_email_id
 }

--- a/example/redash_one_node/main.tf
+++ b/example/redash_one_node/main.tf
@@ -1,3 +1,22 @@
 module "redash" {
   source = "../../"
+
+  redash_admin_username ="admin"
+  redash_admin_password = "admin123"
+  redash_admin_email_id  = "admin@mail.com"
+}
+
+output "redash_username"{
+  description = "Redash admin username"
+  value= module.redash.redash_admin_username
+}
+
+output "redash_password" {
+  description = "Redash admin password"
+  value       = module.redash.redash_admin_password
+}
+
+output "redash_email_id" {
+  description = "Redash admin email id"
+  value       = module.redash.redash_admin_email_id
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,12 @@
 
 data "template_file" "nomad_job_redash_server" {
   template = file("${path.module}/conf/nomad/redash_server.hcl")
+
+  vars = {
+    redash_admin_username = var.redash_admin_username
+    redash_admin_password = var.redash_admin_password
+    redash_admin_email_id  = var.redash_admin_email_id
+  }
 }
 
 data "template_file" "nomad_job_redash_worker" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,14 @@
+output "redash_admin_username" {
+  description = "Redash admin username"
+  value       = data.template_file.nomad_job_redash_server.vars.redash_admin_username
+}
+
+output "redash_admin_password" {
+  description = "Redash admin password"
+  value       = data.template_file.nomad_job_redash_server.vars.redash_admin_password
+}
+
+output "redash_admin_email_id" {
+  description = "Redash admin email id"
+  value       = data.template_file.nomad_job_redash_server.vars.redash_admin_email_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,17 @@
+variable "redash_admin_username" {
+  type        = string
+  description = "Redash admin username"
+  default     = "admin"
+}
+
+variable "redash_admin_password" {
+  type        = string
+  description = "Redash admin password"
+  default     = "admin123"
+}
+
+variable "redash_admin_email_id" {
+  type        = string
+  description = "Redash admin email id"
+  default     = "admin@mail.com"
+}


### PR DESCRIPTION
Creates a default admin user for redash on startup. The output that gets printed after successful execution of ```terraform apply``` command looks like this:
```Outputs:

redash_email_id = admin@mail.com
redash_password = admin123
redash_username = admin

```

