### PR TITLE
`make connect-to-all` now supports MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Corrected the link to the proxy section that shows up when the make command fails
+- Makefile `connect-to-all` supports opening multiple terminals for both Linux and MacOS
 
 ## [0.0.2]
 

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,19 @@ proxy-presto: check_for_consul_binary
 proxy-minio: check_for_consul_binary
 	consul connect proxy -service=proxy-to-minio -upstream=minio:9090 -log-level=TRACE
 
-connect-to-all: check_for_consul_binary
+OS = $(shell uname)
+PWD = $(shell pwd)
+connect-to-all:
+ifeq ($(OS), Linux)
 	gnome-terminal -- make proxy-redash
 	gnome-terminal -- make proxy-presto
 	gnome-terminal -- make proxy-minio
+endif
+ifeq ($(OS), Darwin)
+	osascript -e 'tell application "Terminal" to do script "cd $(PWD); make proxy-redash"'
+	osascript -e 'tell application "Terminal" to do script "cd $(PWD); make proxy-presto"'
+	osascript -e 'tell application "Terminal" to do script "cd $(PWD); make proxy-minio"'
+endif
+ifeq ($(OS),)
+	@echo "You are not on a Linux or Mac. You will need to run the proxies separately:\n  make proxy-redash\n  make proxy-presto\n  make proxy-minio"
+endif

--- a/example/datastack/README.md
+++ b/example/datastack/README.md
@@ -38,7 +38,7 @@ When provisioning of the example is finished you can then open up access to Reda
 make connect-to-all
 ```
 
-> :warning: [gnome-terminal](https://help.gnome.org/users/gnome-terminal/stable/) is required for the command above. If you do not have gnome-terminal you can run `make proxy-redash`, `make proxy-presto`, and `make proxy-presto` in three separate terminal windows to achieve the same as `make connect-to-all`.
+> :warning: this feature is only supported for Linux ([gnome-terminal](https://help.gnome.org/users/gnome-terminal/stable/)) and MacOS ([Default Terminal](https://en.wikipedia.org/wiki/Terminal_(macOS))). If you do have problems you can run `make proxy-redash`, `make proxy-presto`, and `make proxy-presto` in three separate terminal windows to achieve the same as `make connect-to-all`.
 
 You will now have access to Redash, Presto, and MinIO on the addresses below:
 


### PR DESCRIPTION
Closes #22 

* Added a simple check in Makefile that detect **Linux** or **Darwin** systems where 3 terminal windows are opened with connection to *Redash*, *Presto* and *Minio*.