### PR TITLE
limiting the number of jobs run in parallel for matrix testing to 3

### DIFF
--- a/.github/workflows/on_pr_push_master.yml
+++ b/.github/workflows/on_pr_push_master.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: macos-latest
 
     strategy:
-      max-parallel: 3
+      max-parallel: 2
       matrix:
         consul_acl: ["consul_acl_enabled", "consul_acl_disabled"]
         consul_acl_default_policy: ["consul_acl_deny"]

--- a/.github/workflows/on_pr_push_master.yml
+++ b/.github/workflows/on_pr_push_master.yml
@@ -36,6 +36,7 @@ jobs:
     runs-on: macos-latest
 
     strategy:
+      max-parallel: 3
       matrix:
         consul_acl: ["consul_acl_enabled", "consul_acl_disabled"]
         consul_acl_default_policy: ["consul_acl_deny"]


### PR DESCRIPTION
Trying out some temporary fix to get around the github action failures due to timeout, which eventually might be caused due to limited resources available on the virtual machines used by the github runners. 
