### PR TITLE
Ldap secrets managed by vault and updated image for /example/redash_trino_cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Updated
 
 ### Added
+- Fetch ldap secrets from Vault #50
 
 ### Deleted
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 - Fetch ldap secrets from Vault #50
+- Used `create_datasource.py` (function in redash image = `gitlab-container-registry.minerva.loc/datainn/redash-rabbit-edition:ptmin-1394-create-datasources` ) to prevent duplicate data sources #51
 
 ### Deleted
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 - Fetch ldap secrets from Vault #50
-- Used `create_datasource.py` (function in redash image = `gitlab-container-registry.minerva.loc/datainn/redash-rabbit-edition:ptmin-1394-create-datasources` ) to prevent duplicate data sources #51
+- Used `create_datasource.py` (function in redash image = `gitlab-container-registry.minerva.loc/datainn/redash-rabbit-edition:ptmin-1394-create-datasources` ) to prevent duplicate data sources in example/redash_trino_cluster #51
 
 ### Deleted
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ module "postgres" {
 | container\_environment\_variables | Redash environment variables | list(string) | [" "] | no |
 | redis\_service | Redis data-object contains service_name and port. | obj(string, string) | { <br> service = "redash-redis", <br> port = 6379, <br> host = "127.0.0.1" <br> } | no |
 | postgres\_service | Postgres data-object contains service, port, username, password and database name | obj(string, number, string, string, string) | { <br> service = "redash-postgres", <br> port = 5432, <br> username = "username", <br> password = "password",  <br> database_name = "metastore" } | no |
-| postgres_vault_secret | Set of properties to be able to fetch Postgres secrets from vault | obj(bool, string, string, string, string) | { <br> use_vault_provider = false, <br> vault_kv_policy_name = "kv-secret", <br> vault_kv_path = "secret/data/dev/trino", <br> vault_kv_field_username = "username", <br> vault_kv_field_password = "username" <br> } | no |
+| postgres_vault_secret | Set of properties to be able to fetch postgres secrets from vault | obj(bool, string, string, string, string) | { <br> use_vault_provider = false, <br> vault_kv_policy_name = "kv-secret", <br> vault_kv_path = "secret/data/dev/trino", <br> vault_kv_field_username = "username", <br> vault_kv_field_password = "password" <br> } | no |
+| ldap_vault_secret | Set of properties to be able to fetch ldap secrets from vault | obj(bool, string, string, string, string) | { <br> use_vault_provider = false, <br> vault_kv_policy_name = "kv-secret", <br> vault_kv_path = "secret/data/dev/ldap", <br> vault_kv_field_username = "username", <br> vault_kv_field_password = "password" <br> } | no |
 | datasource\_upstreams | List of upstream services (list of object with service_name, port) | list | [" "] | no |
 
 ## Outputs

--- a/dev/ansible/00_generate_secrets_vault.yml
+++ b/dev/ansible/00_generate_secrets_vault.yml
@@ -5,6 +5,8 @@
       minio_secret_key: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=12') }}"
       pg_username: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=12') }}"
       pg_password: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=12') }}"
+      ldap_username: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=12') }}"
+      ldap_password: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=12') }}"
 
 - name: Put credentials for minio in vault k/v
   shell: vault kv put secret/dev/minio access_key="{{ minio_access_key }}" secret_key="{{ minio_secret_key }}"
@@ -25,3 +27,9 @@
       VAULT_ADDR: "{{ lookup('env', 'VAULT_ADDR') }}"
       VAULT_TOKEN: "{{ lookup('env', 'vault_master_token') }}"
 
+- name: Put credentials for ldap in vault k/v
+  shell: vault kv put secret/dev/ldap username="{{ ldap_username }}" password="{{ ldap_password }}"
+  run_once: true
+  environment:
+      VAULT_ADDR: "{{ lookup('env', 'VAULT_ADDR') }}"
+      VAULT_TOKEN: "{{ lookup('env', 'vault_master_token') }}"

--- a/example/redash_one_node/main.tf
+++ b/example/redash_one_node/main.tf
@@ -8,7 +8,7 @@ module "redash" {
   service_name    = "redash"
   host            = "127.0.0.1"
   port            = 5000
-  container_image = "redash/redash:8.0.2.b37747"
+  container_image = "gitlab-container-registry.minerva.loc/datainn/redash-rabbit-edition:ptmin-1394-create-datasources"
   use_canary      = false
 
   redash_config_properties = ["python /app/manage.py database create_tables",
@@ -29,6 +29,22 @@ module "redash" {
     vault_kv_field_username = "username"
     vault_kv_field_password = "password"
   }
+  ldap_vault_secret = {
+    use_vault_provider      = true
+    vault_kv_policy_name    = "kv-secret"
+    vault_kv_path           = "secret/dev/ldap"
+    vault_kv_field_username = "username"
+    vault_kv_field_password = "password"
+  }
+  container_environment_variables = [
+    "REDASH_LDAP_CUSTOM_USERNAME_PROMPT=Brukerid",
+    "REDASH_LDAP_LOGIN_ENABLED=true",
+    "REDASH_PASSWORD_LOGIN_ENABLED=true",
+    "REDASH_LDAP_URL=ldaps://skead.no:636",
+    "REDASH_LDAP_SEARCH_DN='DC=skead,DC=no'",
+    "REDASH_LDAP_SEARCH_TEMPLATE=(&(objectClass=user)(sAMAccountName=%(username)s)(memberof=CN=APP_datainn_utv,OU=Prosjekter,OU=vRAutomation,OU=Produksjon,OU=Applikasjoner,OU=Grupper,DC=skead,DC=no))"
+  ]
+
 }
 
 

--- a/example/redash_one_node/main.tf
+++ b/example/redash_one_node/main.tf
@@ -8,7 +8,7 @@ module "redash" {
   service_name    = "redash"
   host            = "127.0.0.1"
   port            = 5000
-  container_image = "gitlab-container-registry.minerva.loc/datainn/redash-rabbit-edition:ptmin-1394-create-datasources"
+  container_image = "redash/redash:8.0.2.b37747"
   use_canary      = false
 
   redash_config_properties = ["python /app/manage.py database create_tables",
@@ -29,22 +29,6 @@ module "redash" {
     vault_kv_field_username = "username"
     vault_kv_field_password = "password"
   }
-  ldap_vault_secret = {
-    use_vault_provider      = true
-    vault_kv_policy_name    = "kv-secret"
-    vault_kv_path           = "secret/dev/ldap"
-    vault_kv_field_username = "username"
-    vault_kv_field_password = "password"
-  }
-  container_environment_variables = [
-    "REDASH_LDAP_CUSTOM_USERNAME_PROMPT=Brukerid",
-    "REDASH_LDAP_LOGIN_ENABLED=true",
-    "REDASH_PASSWORD_LOGIN_ENABLED=true",
-    "REDASH_LDAP_URL=ldaps://skead.no:636",
-    "REDASH_LDAP_SEARCH_DN='DC=skead,DC=no'",
-    "REDASH_LDAP_SEARCH_TEMPLATE=(&(objectClass=user)(sAMAccountName=%(username)s)(memberof=CN=APP_datainn_utv,OU=Prosjekter,OU=vRAutomation,OU=Produksjon,OU=Applikasjoner,OU=Grupper,DC=skead,DC=no))"
-  ]
-
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -29,12 +29,19 @@ data "template_file" "nomad_job_redash_server" {
     postgres_username      = var.postgres_service.username
     postgres_password      = var.postgres_service.password
     postgres_database_name = var.postgres_service.database_name
-    # if creds ar provided by vault
+    # if creds for postgres are provided by vault
     postgres_use_vault_provider      = var.postgres_vault_secret.use_vault_provider
     postgres_vault_kv_policy_name    = var.postgres_vault_secret.vault_kv_policy_name
     postgres_vault_kv_path           = var.postgres_vault_secret.vault_kv_path
     postgres_vault_kv_field_username = var.postgres_vault_secret.vault_kv_field_username
     postgres_vault_kv_field_password = var.postgres_vault_secret.vault_kv_field_password
+
+    # if creds for ldap are provided by vault
+    ldap_use_vault_provider      = var.ldap_vault_secret.use_vault_provider
+    ldap_vault_kv_policy_name    = var.ldap_vault_secret.vault_kv_policy_name
+    ldap_vault_kv_path           = var.ldap_vault_secret.vault_kv_path
+    ldap_vault_kv_field_username = var.ldap_vault_secret.vault_kv_field_username
+    ldap_vault_kv_field_password = var.ldap_vault_secret.vault_kv_field_password
 
     # Datasource upstreams
     upstreams = jsonencode(var.datasource_upstreams)

--- a/nomad/redash_server.hcl
+++ b/nomad/redash_server.hcl
@@ -102,9 +102,15 @@ EOF
         change_mode = "noop"
         env         = true
         data        = <<EOF
+%{ if ldap_use_vault_provider }
+{{ with secret "${ldap_vault_kv_path}" }}
+REDASH_LDAP_BIND_DN="{{ .Data.data.${ldap_vault_kv_field_username} }}"
+REDASH_LDAP_BIND_DN_PASSWORD="{{ .Data.data.${ldap_vault_kv_field_password} }}"
+{{ end }}
+%{ endif }
 ${envs}
 EOF
-      }
+}
       resources {
         cpu    = "${cpu}" # MHz
         memory = "${memory}" # MB

--- a/variables.tf
+++ b/variables.tf
@@ -131,6 +131,24 @@ variable "postgres_vault_secret" {
   }
 }
 
+variable "ldap_vault_secret" {
+  type = object({
+    use_vault_provider      = bool,
+    vault_kv_policy_name    = string,
+    vault_kv_path           = string,
+    vault_kv_field_username = string,
+    vault_kv_field_password = string
+  })
+  description = "Set of properties to be able to fetch Ldap secrets from vault"
+  default = {
+    use_vault_provider      = false
+    vault_kv_policy_name    = "kv-secret"
+    vault_kv_path           = "secret/data/dev/ldap"
+    vault_kv_field_username = "username"
+    vault_kv_field_password = "password"
+  }
+}
+
 # Datasources
 variable "datasource_upstreams" {
   type = list(object({

--- a/variables.tf
+++ b/variables.tf
@@ -139,7 +139,7 @@ variable "ldap_vault_secret" {
     vault_kv_field_username = string,
     vault_kv_field_password = string
   })
-  description = "Set of properties to be able to fetch Ldap secrets from vault"
+  description = "Set of properties to be able to fetch ldap secrets from Vault"
   default = {
     use_vault_provider      = false
     vault_kv_policy_name    = "kv-secret"


### PR DESCRIPTION
## Closes/fixes/resolves issue(s)?
Closes #50 
Closes #51 

## What was added/changed/fixed?
- Fetch ldap secrets from Vault #50
- Used `create_datasource.py` (function in redash image = `gitlab-container-registry.minerva.loc/datainn/redash-rabbit-edition:ptmin-1394-create-datasources` ) to prevent duplicate data sources in example/redash_trino_cluster #51

## Checklist (after created PR)
- [x] Added reviewers
- [ ] Added assignee(s)
- [x] Added label(s)
- [ ] Added to project
- [x] Added to milestone
- Need to update documentation? (Y/n)